### PR TITLE
Implement disabled styling for sell tokens with no balance

### DIFF
--- a/css/components/forms.css
+++ b/css/components/forms.css
@@ -1310,6 +1310,22 @@
   opacity: 1;
 }
 
+/* Disabled token styling for sell selection */
+.token-disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.token-disabled:hover {
+  background-color: inherit;
+  border-color: inherit;
+}
+
+.token-disabled .token-item-content {
+  opacity: 0.6;
+}
+
 .has-balance {
   color: #059669;
   font-weight: 600;

--- a/js/components/CreateOrder.js
+++ b/js/components/CreateOrder.js
@@ -1176,6 +1176,11 @@ export class CreateOrder extends BaseComponent {
             const hasBalance = balance > 0;
             
             tokenElement.className = `token-item ${hasBalance ? 'token-has-balance' : 'token-no-balance'}`;
+            
+            // For sell tokens, add disabled class if no balance
+            if (type === 'sell' && !hasBalance) {
+                tokenElement.classList.add('token-disabled');
+            }
             tokenElement.dataset.address = token.address;
             
             // Format balance with up to 4 decimal places if they exist
@@ -1270,6 +1275,7 @@ export class CreateOrder extends BaseComponent {
                 <div class="summary-text">
                     Showing ${totalTokens} allowed tokens
                     ${tokensWithBalance > 0 ? `(${tokensWithBalance} with balance)` : ''}
+                    ${type === 'sell' && tokensWithBalance < totalTokens ? ` - ${totalTokens - tokensWithBalance} disabled (no balance)` : ''}
                 </div>
             `;
             container.appendChild(summaryElement);
@@ -1770,6 +1776,15 @@ export class CreateOrder extends BaseComponent {
             });
             
             if (token) {
+                // For sell tokens, check if balance is zero
+                if (type === 'sell') {
+                    const balance = Number(token.balance) || 0;
+                    if (balance <= 0) {
+                        this.showWarning(`${token.symbol} has no balance available for selling. Please select a token with a balance.`);
+                        return; // Don't allow selection of tokens with zero balance for selling
+                    }
+                }
+                
                 // Validate that the token is allowed in the contract
                 try {
                     const isAllowed = await contractService.isTokenAllowed(address);


### PR DESCRIPTION
- Added CSS class `.token-disabled` to visually indicate tokens that cannot be sold due to insufficient balance.
- Updated `CreateOrder` component to apply the disabled class for sell tokens when the balance is zero.
- Enhanced user feedback by displaying a message indicating the number of disabled tokens in the summary section.

Key improvements:
- Improved user experience by clearly signaling which tokens are unavailable for selling.
- Enhanced visual feedback for token selection based on balance status.